### PR TITLE
Add link to training topic

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,8 +34,11 @@
             <li class="p-navigation__item {% if request.path == '/masterclasses' %}is-selected{% endif %}">
               <a class="p-navigation__link" href="/masterclasses">Masterclasses</a>
             </li>
-            <li class="p-navigation__item {% if request.path == '/guides' %}is-selected{% endif %}">
+            <li class="p-navigation__item">
               <a class="p-navigation__link" href="https://discourse.canonical.com/c/web-and-design-team/guides/16">Guides</a>
+            </li>
+            <li class="p-navigation__item">
+              <a class="p-navigation__link" href="https://discourse.canonical.com/t/recommended-training/1492">Training</a>
             </li>
             <li class="p-navigation__item {% if request.path == '/releases' %}is-selected{% endif %}">
               <a class="p-navigation__link" href="/releases">Releases</a>


### PR DESCRIPTION
We want to have an official place for people to find useful and relevant training courses, so they can make more effective use of their training budget.

This was [suggested by @mtruj013 in a dev catch-up last November](https://github.com/canonical/web-design-meetings/issues/97).

So here I'm adding a "Training" link to the top of webteam.canonical.com, which links to a new Discourse topic I started to keep track of this stuff.

Fixes https://warthogs.atlassian.net/browse/WD-935

## QA

Click on "Training". Voila.