### PR TITLE
Add library.canonical.com to releases page

### DIFF
--- a/webapp/releases.py
+++ b/webapp/releases.py
@@ -136,6 +136,11 @@ domain_repositories = [
         "staging_domain": "staging.vanillaframework.io",
         "repository": "canonical-web-and-design/vanilla-framework",
     },
+    {
+        "production_domain": "library.canonical.com",
+        "staging_domain": "library.staging.canonical.com",
+        "repository": "canonical-web-and-design/canonical",
+    },
 ]
 
 releases = Blueprint(


### PR DESCRIPTION
## Done

**note** this won't show it is live yet as we have not deployed
Add library.canonical.com to releases page
