### PR TITLE
Limit the returned upcoming events to rows with values

### DIFF
--- a/tests/test_masterclasses.py
+++ b/tests/test_masterclasses.py
@@ -1,0 +1,26 @@
+import unittest
+from webapp.masterclasses import _has_row_value
+
+
+class TestMasterclassesApp(unittest.TestCase):
+    def test_has_row_value_return_true(self):
+        row = {
+            "values": [
+                {
+                    "userEnteredValue": {
+                        "stringValue": "Redis",
+                    },
+                    "effectiveValue": {
+                        "stringValue": "Redis",
+                    },
+                    "formattedValue": "Redis",
+                }
+            ]
+        }
+        self.assertTrue(_has_row_value(row))
+
+    def test_has_row_value_return_false(self):
+        row = {
+            "userEnteredFormat": {"hyperlinkDisplayType": "LINKED"},
+        }
+        self.assertFalse(_has_row_value(row))

--- a/webapp/masterclasses.py
+++ b/webapp/masterclasses.py
@@ -96,7 +96,7 @@ def get_upcoming_sessions():
 
     sessions = []
     for row in res["sheets"][0]["data"][0]["rowData"]:
-        if "values" in row and row["values"][0]:
+        if _has_row_value(row):
             session = {}
             for column_index in range(len(COLUMNS)):
                 (column, type) = COLUMNS[column_index]
@@ -158,3 +158,13 @@ def get_previous_sessions():
     sessions.sort(key=lambda x: x["Date"]["Object"], reverse=True)
 
     return sessions
+
+
+def _has_row_value(row):
+    if (
+        "values" in row
+        and row["values"][0]
+        and "userEnteredValue" in row["values"][0]
+    ):
+        return True
+    return False


### PR DESCRIPTION
## Done

Only display the up-coming events when there is a user-entered value in the row.

## QA
1. Pull this branch and use `dotrun` to run the app locally (You will need creds which can be found in the team LastPass)
2. Go to http://0.0.0.0:8103/masterclasses
3. See there is a small set of Upcoming sessions instead of hundreds
