### PR TITLE
Use the ps5 registry for pushing the docker image to

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -1,6 +1,6 @@
 domain: webteam.canonical.com
 
-image: prod-comms.docker-registry.canonical.com/webteam.canonical.com
+image: prod-comms.ps5.docker-registry.canonical.com/webteam.canonical.com
 
 env:
   - name: SENTRY_DSN


### PR DESCRIPTION
This is a test to see if the PS4.5 K8s cluster can use the PS5 registry.

If so, then if we just switch everything over to using the PS5 registry right now, then it will probably work better and then we don't need to support two different types of registry configuration in our [deploy script][1].

[1]: https://github.com/canonical/webteam-jenkins-scripts/blob/main/deploy-sites/deploy-sites.sh

## QA

See https://jenkins.canonical.com/webteam/job/webteam.canonical.com/94/console succeeded in both clusters using `prod-comms.ps5.docker-registry.canonical.com`
